### PR TITLE
Replace lumen-vendor-publish with larasupport

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -68,17 +68,15 @@ $app->withEloquent();
 The `vendor:publish` command doesn't exist in Lumen, so an extra package must be installed:
 
 ```sh
-composer require laravelista/lumen-vendor-publish
+composer require irazasyed/larasupport
 ```
 
-After the package is installed, the command must be registered in `app/Console/Kernel.php`:
+After the package is installed, the service provider must be registered in `bootstrap/app.php`:
 
 ```php
 // ...
 
-protected $commands = [
-    \Laravelista\LumenVendorPublish\VendorPublishCommand::class,
-];
+$app->register(Irazasyed\Larasupport\Providers\ArtisanServiceProvider::class);
 
 // ...
 ```


### PR DESCRIPTION
https://github.com/laravelista/lumen-vendor-publish
>will stop working if I update VendorPublishCommand to match the latest Laravel version because of [VendorTagPublish](https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Foundation/Events/VendorTagPublished.php) being placed inside laravel/framework meaning that you would have to pull entire Laravel framework in your Lumen app just to get that class
>This means that I will archive this package for good.
If you need to publish resources, you can copy the files manually or use Laravel instead.

Alternative
https://github.com/irazasyed/larasupport