### PR TITLE
Correcting the older of fields

### DIFF
--- a/docs/guide/audit-migration.md
+++ b/docs/guide/audit-migration.md
@@ -36,11 +36,11 @@ $table->nullableMorphs('user');
 to
 
 ```php
-$table->uuid('user_id')->nullable();
 $table->string('user_type')->nullable();
+$table->uuid('user_id')->nullable();
 $table->index([
-    'user_id', 
     'user_type',
+    'user_id', 
 ]);
 ```
 
@@ -52,11 +52,11 @@ $table->morphs('auditable');
 to
 
 ```php
-$table->uuid('auditable_id');
 $table->string('auditable_type');
+$table->uuid('auditable_id');
 $table->index([
-    'auditable_id', 
     'auditable_type',
+    'auditable_id', 
 ]);
 ```
 


### PR DESCRIPTION
When a migration uses `->morphs()` it first creates the `_type` field, then the `_id` field.

To maintain the `audits` table field order, when customizing the morph fields, I have swapped the order of the fields.