### PR TITLE
`withoutAuditing()` method documentation

### DIFF
--- a/docs/guide/auditable-configuration.md
+++ b/docs/guide/auditable-configuration.md
@@ -364,3 +364,47 @@ Article::create([
 // Re-enable auditing
 Article::enableAuditing();
 ```
+
+For version **13.6.6** and above, you may temporarily disable auditing for a given class within a callback.
+The static `withoutAuditing` method accepts a closure as its only argument. Any value returned by the
+closure will be returned by the withoutAuditing method.
+
+```php
+<?php
+
+$article = Article::withoutAuditing(function () {
+    // This operation won't be audited
+    $article = Article::create([
+        // ...
+    ]);
+
+    // This operation will be audited
+    Category::create([
+        'article_id' => $article->id,
+        // ...
+    ]);
+
+    return $article;
+});
+```
+
+To temporarily disable auditing for more than one class, the `withoutAuditing` method must be called for each.
+
+```php
+<?php
+
+$article = Article::withoutAuditing(function () {
+    // This operation won't be audited
+    $article = Article::create([
+        // ...
+    ]);
+
+    // This operation won't be audited
+    Category::withoutAuditing(fn () => Category::create([
+        'article_id' => $article->id,
+        // ...
+    ]));
+
+    return $article;
+});
+```


### PR DESCRIPTION
## Summary

Add 2 examples for `Auditable::withoutEvents()` under the "Auditable Configuration" section "Enable/Disable".

If `withoutAuditing()` is added to v14 instead of the next minor version, "13.6.6" in this PR should be updated to the next expected release tag.

## Demo

<img width="826" alt="without-events-docs" src="https://github.com/owen-it/laravel-auditing.com/assets/823566/3e69f49b-f6da-4629-8abe-8eec7b5da0d8">

## Dependencies

* https://github.com/owen-it/laravel-auditing/pull/917

## Links

* https://laravel.com/docs/11.x/eloquent#muting-events Copy for a similar feature in the official Laravel docs.